### PR TITLE
make it so that a user can only react once

### DIFF
--- a/components/app.tsx
+++ b/components/app.tsx
@@ -674,26 +674,27 @@ export default function App() {
         return prevConversations.map((conversation) => {
           const messages = conversation.messages.map((message) => {
             if (message.id === messageId) {
-              // Check if this reaction type from this sender already exists
-              const existingReactionIndex =
-                message.reactions?.findIndex(
-                  (r) =>
-                    r.type === reaction.type && r.sender === reaction.sender
-                ) ?? -1;
+              // Check if this exact reaction already exists
+              const existingReaction = message.reactions?.find(
+                (r) => r.sender === reaction.sender && r.type === reaction.type
+              );
 
-              if (existingReactionIndex === -1) {
-                // Add new reaction
+              if (existingReaction) {
+                // If the same reaction exists, remove it
                 return {
                   ...message,
-                  reactions: [...(message.reactions || []), reaction],
+                  reactions: message.reactions?.filter(
+                    (r) => !(r.sender === reaction.sender && r.type === reaction.type)
+                  ) || [],
                 };
               } else {
-                // Remove existing reaction
-                const newReactions = [...(message.reactions || [])];
-                newReactions.splice(existingReactionIndex, 1);
+                // Remove any other reaction from this sender and add the new one
+                const otherReactions = message.reactions?.filter(
+                  (r) => r.sender !== reaction.sender
+                ) || [];
                 return {
                   ...message,
-                  reactions: newReactions,
+                  reactions: [...otherReactions, reaction],
                 };
               }
             }

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -90,11 +90,6 @@ export function MessageBubble({
   const handleReaction = useCallback(
     (type: ReactionType) => {
       if (onReaction) {
-        // Check if this reaction type already exists
-        const isExistingReaction = message.reactions?.some(
-          (r) => r.type === type && r.sender === "me"
-        );
-
         // Create reaction with current timestamp
         const reaction: Reaction = {
           type,
@@ -102,10 +97,8 @@ export function MessageBubble({
           timestamp: new Date().toISOString(),
         };
 
-        // Only play sound if adding a new reaction
-        if (!isExistingReaction) {
-          soundEffects.playReactionSound();
-        }
+        // Play sound for any reaction action
+        soundEffects.playReactionSound();
 
         // Send reaction to parent
         onReaction(message.id, reaction);
@@ -120,7 +113,6 @@ export function MessageBubble({
     },
     [
       message.id,
-      message.reactions,
       onReaction,
       onOpenChange,
       onReactionComplete,


### PR DESCRIPTION
a user can only react once to a message, so: 
if you heart a message and click heart again, it will remove the heart reaction
if you heart a message and click laugh, it will replace the heart with laugh
if you then click laugh again, it will remove the laugh reaction

![CleanShot 2025-01-23 at 09 12 47](https://github.com/user-attachments/assets/7e399d5a-9e8c-40c8-a1b9-c9311c0a973d)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Users can only have one active reaction per message, with sound effects playing for any reaction action.
> 
>   - **Behavior**:
>     - Users can only have one active reaction per message. Clicking the same reaction removes it; clicking a different one replaces it.
>     - Sound effects play for any reaction action, not just new ones.
>   - **Code Changes**:
>     - In `components/app.tsx`, `handleReaction` now removes existing reactions of the same type and sender, or replaces them with a new reaction.
>     - In `components/message-bubble.tsx`, `handleReaction` no longer checks for existing reactions before playing sound effects.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=alanagoyal%2Fmessages&utm_source=github&utm_medium=referral)<sup> for a90c2ddaf337755881752635eb85ca16a09da510. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->