### PR TITLE
fix clicking out of header on mobile

### DIFF
--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -368,9 +368,14 @@ export function ChatHeader({
             if (isEditMode) {
               setIsEditMode(false);
               onUpdateRecipients?.(currentRecipients);
-            } else if (isNewChat && !isMobileView) {
-              setShowCompactNewChat?.(true);
-              onCreateConversation?.(currentRecipients);
+            } else if (isNewChat) {
+              if (isMobileView) {
+                setShowResults(false);
+                onCreateConversation?.(currentRecipients);
+              } else {
+                setShowCompactNewChat?.(true);
+                onCreateConversation?.(currentRecipients);
+              }
             }
 
             // Add a capture event listener to block the next click


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `ChatHeader` behavior for mobile by hiding results when clicking outside during new chat creation.
> 
>   - **Behavior**:
>     - In `ChatHeader`, when clicking outside the header during a new chat, if `isMobileView` is true, `setShowResults(false)` is called before `onCreateConversation`.
>     - For non-mobile views, `setShowCompactNewChat(true)` is called before `onCreateConversation`.
>   - **Functions**:
>     - Modified logic in `handleClickOutside` in `ChatHeader` to handle mobile and non-mobile views differently when creating a new chat.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=alanagoyal%2Fmessages&utm_source=github&utm_medium=referral)<sup> for c7535512f9c4ee96b73549e5ea3140531facc26d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->